### PR TITLE
Support non-superuser

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,13 @@ jobs:
           git clone --depth 1 --branch release/PG16/1.5.0 https://github.com/apache/age.git ~/age16source
           cd ~/age16source
           make PG_CONFIG=$HOME/pg16/bin/pg_config install
+          mkdir -p $HOME/pg16/lib/postgresql/plugins && ln -s $HOME/pg16/lib/postgresql/age.so $HOME/pg16/lib/postgresql/plugins/age.so
           cd ~/pg16
           mkdir data
           bin/initdb -D data
           bin/pg_ctl -D data -l logfile start
           bin/createuser -s postgres
           bin/createdb -O "postgres" agedotnet_tests
-          mkdir -p $HOME/pg16/lib/plugins && ln -s $HOME/pg16/lib/age.so $HOME/pg16/lib/plugins/age.so
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,64 +10,65 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '5.0.x', '6.0.x', '7.0.x', '8.0.x' ]
+        dotnet-version: ["5.0.x", "6.0.x", "7.0.x", "8.0.x"]
     steps:
-    - name: Get latest commit id of PostgreSQL 16
-      run: |
-        echo "PG_COMMIT_HASH=$(git ls-remote git://git.postgresql.org/git/postgresql.git refs/heads/REL_16_STABLE | awk '{print $1}')" >> $GITHUB_ENV
+      - name: Get latest commit id of PostgreSQL 16
+        run: |
+          echo "PG_COMMIT_HASH=$(git ls-remote git://git.postgresql.org/git/postgresql.git refs/heads/REL_16_STABLE | awk '{print $1}')" >> $GITHUB_ENV
 
-    - name: Cache PostgreSQL 16 with AGE installed
-      uses: actions/cache@v3
-      id: pg16cache
-      with:
-        path: ~/pg16
-        key: ${{ runner.os }}-v1-pg16-${{ env.PG_COMMIT_HASH }}
-    
-    - name: Get latest commit id of Apache AGE for PG 16
-      run: |
-        echo "AGE_COMMIT_HASH=$(git ls-remote https://github.com/apache/age.git refs/heads/release/PG16/1.5.0 | awk '{print $1}')" >> $GITHUB_ENV
+      - name: Cache PostgreSQL 16 with AGE installed
+        uses: actions/cache@v3
+        id: pg16cache
+        with:
+          path: ~/pg16
+          key: ${{ runner.os }}-v1-pg16-${{ env.PG_COMMIT_HASH }}
 
-    - name: Install PostgreSQL 16 and AGE, create default user and databases
-      if: steps.pg16cache.outputs.cache-hit != 'true'
-      run: |
-        git clone --depth 1 --branch REL_16_STABLE git://git.postgresql.org/git/postgresql.git ~/pg16source
-        cd ~/pg16source
-        ./configure --prefix=$HOME/pg16 CFLAGS="-std=gnu99 -ggdb -O0" --enable-cassert
-        make install -j$(nproc) > /dev/null
-        git clone --depth 1 --branch release/PG16/1.5.0 https://github.com/apache/age.git ~/age16source
-        cd ~/age16source
-        make PG_CONFIG=$HOME/pg16/bin/pg_config install
-        cd ~/pg16
-        mkdir data
-        bin/initdb -D data
-        bin/pg_ctl -D data -l logfile start
-        bin/createuser -s postgres
-        bin/createdb -O "postgres" agedotnet_tests
-        
-    - uses: actions/checkout@v4
-    
-    - name: Setup .NET ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ matrix.dotnet-version }}
-        
-      # You can test your matrix by printing the current dotnet version
-    - name: Display dotnet version
-      run: dotnet --version
-      
-    - name: Restore dependencies
-      run: dotnet restore
-      
-    - name: Build
-      run: dotnet build --no-restore
-      
-    - name: Test with dotnet
-      run: dotnet test --logger trx --results-directory "TestResults-${{ matrix.dotnet-version }}"
-      
-    - name: Upload dotnet test results
-      uses: actions/upload-artifact@v4
-      with:
-        name: dotnet-results-${{ matrix.dotnet-version }}
-        path: TestResults-${{ matrix.dotnet-version }}
-      # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
+      - name: Get latest commit id of Apache AGE for PG 16
+        run: |
+          echo "AGE_COMMIT_HASH=$(git ls-remote https://github.com/apache/age.git refs/heads/release/PG16/1.5.0 | awk '{print $1}')" >> $GITHUB_ENV
+
+      - name: Install PostgreSQL 16 and AGE, create default user and databases
+        if: steps.pg16cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch REL_16_STABLE git://git.postgresql.org/git/postgresql.git ~/pg16source
+          cd ~/pg16source
+          ./configure --prefix=$HOME/pg16 CFLAGS="-std=gnu99 -ggdb -O0" --enable-cassert
+          make install -j$(nproc) > /dev/null
+          git clone --depth 1 --branch release/PG16/1.5.0 https://github.com/apache/age.git ~/age16source
+          cd ~/age16source
+          make PG_CONFIG=$HOME/pg16/bin/pg_config install
+          mkdir -p $HOME/pg16/lib/plugins && ln -s $HOME/pg16/lib/age.so $HOME/pg16/lib/plugins/age.so
+          cd ~/pg16
+          mkdir data
+          bin/initdb -D data
+          bin/pg_ctl -D data -l logfile start
+          bin/createuser -s postgres
+          bin/createdb -O "postgres" agedotnet_tests
+
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+        # You can test your matrix by printing the current dotnet version
+      - name: Display dotnet version
+        run: dotnet --version
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test with dotnet
+        run: dotnet test --logger trx --results-directory "TestResults-${{ matrix.dotnet-version }}"
+
+      - name: Upload dotnet test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-results-${{ matrix.dotnet-version }}
+          path: TestResults-${{ matrix.dotnet-version }}
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
           bin/pg_ctl -D data -l logfile start
           bin/createuser -s postgres
           bin/createdb -O "postgres" agedotnet_tests
-          mkdir -p lib/plugins && ln -s lib/age.so lib/plugins/age.so
+          mkdir -p $HOME/pg16/lib/plugins && ln -s $HOME/pg16/lib/age.so $HOME/pg16/lib/plugins/age.so
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,13 @@ jobs:
           git clone --depth 1 --branch release/PG16/1.5.0 https://github.com/apache/age.git ~/age16source
           cd ~/age16source
           make PG_CONFIG=$HOME/pg16/bin/pg_config install
-          mkdir -p $HOME/pg16/lib/plugins && ln -s $HOME/pg16/lib/age.so $HOME/pg16/lib/plugins/age.so
           cd ~/pg16
           mkdir data
           bin/initdb -D data
           bin/pg_ctl -D data -l logfile start
           bin/createuser -s postgres
           bin/createdb -O "postgres" agedotnet_tests
+          mkdir -p lib/plugins && ln -s lib/age.so lib/plugins/age.so
 
       - uses: actions/checkout@v4
 

--- a/src/ApacheAGE/IAgeClient.cs
+++ b/src/ApacheAGE/IAgeClient.cs
@@ -31,6 +31,22 @@ namespace ApacheAGE
         Task OpenConnectionAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Opens connection to the database and performs the necessary actions to create 
+        /// and load the AGE extension in the database. 
+        /// </summary>
+        /// <param name="superUser">
+        /// Indicates if the connection should be made as a super user.
+        /// If <see langword="false"/>, the AGE extension will be loaded from $libdir/plugins/ago.so.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Token for propagating a notification  stop the running operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> for monitoring the progress of the operation.
+        /// </returns>
+        Task OpenConnectionAsync(bool superUser, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Create a graph if it doesn't exist.
         /// </summary>
         /// <param name="graphName">


### PR DESCRIPTION
The `LOAD 'age'`; command is only allowed as a superuser. To run AGE as a non-superuser, the recommended approach is to load the extension with `LOAD '$libdir/plugins/age';` (and to grant access to ag_catalog.

The Apache AGE documentation references this [here](https://age.apache.org/age-manual/master/intro/setup.html#allow-non-superusers-to-use-apache-age) and there's an issue related to this [here](https://github.com/apache/age/issues/839#issuecomment-1950302589) (related to the Python driver, but it's the same principle).

To support this, without breaking any existing usage, an overloaded OpenConnection method was provided that allows to pass a boolean to load the AGE extension as a non-superuser.
One of the existing tests was copied to run with this setup, which also required to copy the extension to the correct location in the github actions.